### PR TITLE
Travis/pypi

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 .*
+*.egg-info
 !.gitignore
+!.travis.yml
+build
+dist

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: python
+
+python: "3.4"
+
+script: make build
+
+before_deploy: pip install twine
+
+deploy:
+  provider: script
+  script: twine upload -u $PYPI_USERNAME -p $PYPI_PASSWORD dist/*

--- a/Makefile
+++ b/Makefile
@@ -5,3 +5,7 @@ build: clean
 .PHONY: clean
 clean:
 	rm -rf *.egg-info build dist
+
+.PHONY: install
+install: build
+	pip install dist/cli50*.tar.gz

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,7 @@
+.PHONY: build
+build: clean
+	python3 setup.py sdist
+
+.PHONY: clean
+clean:
+	rm -rf *.egg-info build dist

--- a/README
+++ b/README
@@ -1,0 +1,3 @@
+# CS50 CLI
+
+This is CS50 CLI, with which you can mount a directory inside of an Ubuntu container.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,0 @@
-# CS50 CLI
-
-TODO

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,19 @@
+from setuptools import setup
+
+setup(
+    author="CS50",
+    author_email="sysadmins@cs50.harvard.edu",
+    classifiers=[
+        "Intended Audience :: Developers",
+        "Intended Audience :: System Administrators",
+        "Programming Language :: Python",
+        "Programming Language :: Python :: 3",
+        "Topic :: Software Development"
+    ],
+    description="This is CS50 CLI, with which you can mount a directory inside of an Ubuntu container.",
+    keywords="cli50",
+    name="cli50",
+    scripts=["cli50"],
+    url="https://github.com/cs50/cli50",
+    version="1.0.0"
+)


### PR DESCRIPTION
This should build sdist and deploy automatically to PyPI on commits to master.

**Prerequisites:**
 * Enabling Travis for cs50/cli
 * Adding PyPi username and password as `PYPI_USERNAME` and `PYPI_PASSWORD` environment variables respectively on Travis

@dmalan, though I can see the project on Travis, sounds like I don't have rights to enable Travis for this repo or add environment variables through the project settings there.