### PR TITLE
renames README to README.md [skip ci]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 !.travis.yml
 build
 dist
+README.txt

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 .PHONY: build
 build: clean
+	ln -f -s README.md README.txt
 	python3 setup.py sdist
 
 .PHONY: clean

--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
 # CS50 CLI
 
-![Build Status](https://travis-ci.org/kzidane/cli50.svg?branch=master)
-
 This is CS50 CLI, with which you can mount a directory inside of an Ubuntu container.


### PR DESCRIPTION
For GitHub. And symlinks to README.txt, while building, for sdist.