### PR TITLE
fixed -V

### DIFF
--- a/cli50
+++ b/cli50
@@ -17,17 +17,10 @@ if sys.version_info < (3, 0):
     input = raw_input
 
 # Get version
-# https://stackoverflow.com/a/17638236/5156190
 try:
-    _dist = pkg_resources.get_distribution("cli50")
-    dist_loc = os.path.normcase(_dist.location)
-    here = os.path.normcase(__file__)
-    if not here.startswith(os.path.join(dist_loc, "cli50")):
-        raise pkg_resources.DistributionNotFound
+    __version__ = pkg_resources.get_distribution("cli50").version
 except pkg_resources.DistributionNotFound:
     __version__ = "UNKNOWN"
-else:
-    __version__ = _dist.version
 
 
 def main():

--- a/setup.py
+++ b/setup.py
@@ -15,5 +15,5 @@ setup(
     name="cli50",
     scripts=["cli50"],
     url="https://github.com/cs50/cli50",
-    version="1.9.0"
+    version="1.9.1"
 )


### PR DESCRIPTION
Any reason not to do it this way per no. 5 here: https://packaging.python.org/guides/single-sourcing-package-version/?

#28 

```
$ ./cli50 -V
cli50 UNKNOWN
$ pip install -e .
Obtaining file:///home/kzidane/github/cs50/cli50
Installing collected packages: cli50
  Running setup.py develop for cli50
Successfully installed cli50
$ cli50 -V
cli50 1.9.0
```