### PR TITLE
catching SIGINT

### DIFF
--- a/cli50
+++ b/cli50
@@ -2,7 +2,7 @@
 
 import signal
 import sys
-signal.signal(signal.SIGINT, lambda signalnum, handler: sys.exit(1))
+signal.signal(signal.SIGINT, lambda signum, frame: sys.exit(1))
 
 import argparse
 import distutils.spawn

--- a/cli50
+++ b/cli50
@@ -1,5 +1,9 @@
 #!/usr/bin/env python3
 
+import signal
+import sys
+signal.signal(signal.SIGINT, lambda signalnum, handler: sys.exit(1))
+
 import argparse
 import distutils.spawn
 import inflect
@@ -9,9 +13,7 @@ import pkg_resources
 import re
 import shlex 
 import shutil
-import signal
 import subprocess
-import sys
 
 
 # Require Python 3.6

--- a/setup.py
+++ b/setup.py
@@ -17,5 +17,5 @@ setup(
     python_requires=">=3.6",
     scripts=["cli50"],
     url="https://github.com/cs50/cli50",
-    version="2.4.1"
+    version="2.4.2"
 )


### PR DESCRIPTION
Prevents ugliness if user hits ctrl-c quickly.

```
$ ./cli50
^CTraceback (most recent call last):
  File "./cli50", line 8, in <module>
    import pkg_resources
  File "/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/site-packages/pkg_resources/__init__.py", line 74, in <module>
    __import__('pkg_resources.extern.packaging.requirements')
  File "/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/site-packages/pkg_resources/_vendor/packaging/requirements.py", line 9, in <module>
    from pkg_resources.extern.pyparsing import stringStart, stringEnd, originalTextFor, ParseException
  File "<frozen importlib._bootstrap>", line 971, in _find_and_load
  File "<frozen importlib._bootstrap>", line 955, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 656, in _load_unlocked
  File "<frozen importlib._bootstrap>", line 626, in _load_backward_compatible
  File "/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/site-packages/pkg_resources/extern/__init__.py", line 43, in load_module
    __import__(extant)
  File "/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/site-packages/pkg_resources/_vendor/pyparsing.py", line 5318, in <module>
    anyOpenTag,anyCloseTag = makeHTMLTags(Word(alphas,alphanums+"_:").setName('any tag'))
  File "/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/site-packages/pkg_resources/_vendor/pyparsing.py", line 2662, in __init__
    self.re = re.compile( self.reString )
  File "/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/re.py", line 233, in compile
    return _compile(pattern, flags)
  File "/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/re.py", line 301, in _compile
    p = sre_compile.compile(pattern, flags)
  File "/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/sre_compile.py", line 566, in compile
    code = _code(p, flags)
  File "/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/sre_compile.py", line 548, in _code
    _compile_info(code, p, flags)
  File "/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/sre_compile.py", line 525, in _compile_info
    emit(min(hi, MAXCODE))
KeyboardInterrupt
```