### PR TITLE
Ensure Apple Silicon compatibility

### DIFF
--- a/cli50/__main__.py
+++ b/cli50/__main__.py
@@ -170,6 +170,7 @@ def main():
     options = ["--detach",
                "--interactive",
                "--label", LABEL,
+               "--platform", "linux/amd64",
                "--rm",
                "--security-opt", "seccomp=unconfined",  # https://stackoverflow.com/q/35860527#comment62818827_35860527, https://github.com/apple/swift-docker/issues/9#issuecomment-328218803
                "--tty",


### PR DESCRIPTION
Adds flag per https://docs.docker.com/docker-for-mac/apple-silicon:

> Not all images are available for ARM64 architecture. You can add --platform linux/amd64 to run an Intel image under emulation.