### PR TITLE
Remove hardcoded platform flag

### DIFF
--- a/cli50/__main__.py
+++ b/cli50/__main__.py
@@ -197,7 +197,6 @@ def main():
                "--env", f"WORKDIR={workdir}",
                "--interactive",
                "--label", LABEL,
-               "--platform", "linux/amd64",
                "--rm",
                "--security-opt", "seccomp=unconfined",  # https://stackoverflow.com/q/35860527#comment62818827_35860527, https://github.com/apple/swift-docker/issues/9#issuecomment-328218803
                "--tty",

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,6 @@ setup(
         "console_scripts": ["cli50=cli50.__main__:main"]
     },
     url="https://github.com/cs50/cli50",
-    version="7.1.3",
+    version="7.1.4",
     include_package_data=True
 )


### PR DESCRIPTION
This allows Docker to automatically pull a matching image for M1 now that it is available. Tested locally.