### PR TITLE
Use docker manifest to determine local image digest

### DIFF
--- a/cli50/__main__.py
+++ b/cli50/__main__.py
@@ -163,6 +163,10 @@ def main():
     # Check Docker Hub for newer image
     if not args["fast"]:
 
+        # Determine platform architecture
+        arch = subprocess.check_output(["uname", "-m"], stderr=subprocess.DEVNULL).decode("utf-8").strip()
+        arch = "amd64" if arch == "x86_64" else "arm64"
+
         # Remote digest
         try:
             digest = requests.get(f"https://registry.hub.docker.com/v2/repositories/{IMAGE}/tags/{args['tag']}").json()["images"][0]["digest"]
@@ -171,18 +175,22 @@ def main():
 
         # Local digest
         try:
-            RepoDigest = json.loads(subprocess.check_output([
-                "docker", "inspect", f"{IMAGE}:{args['tag']}"
-            ], stderr=subprocess.DEVNULL).decode("utf-8"))[0]["RepoDigests"][0]
+            Manifest = json.loads(subprocess.check_output([
+                "docker", "manifest", "inspect", f"{IMAGE}:{args['tag']}"
+            ], stderr=subprocess.DEVNULL).decode("utf-8"))
+            for manifest in Manifest["manifests"]:
+                if manifest["platform"]["architecture"] == arch:
+                    ManifestDigest = f"{IMAGE}@{manifest['digest']}"
+
         except (IndexError, subprocess.CalledProcessError):
-            RepoDigest = None
+            ManifestDigest = None
 
         # Pull image if no local digist
-        if not RepoDigest:
+        if not ManifestDigest:
             pull(IMAGE, args["tag"])
 
         # Ask to update image if local digest doesn't match remote digest
-        elif digest and RepoDigest and f"{IMAGE}@{digest}" != RepoDigest:
+        elif digest and ManifestDigest and f"{IMAGE}@{digest}" != ManifestDigest:
             try:
                 response = input(f"A newer version of {IMAGE}:{args['tag']} is available. Pull now? [Y/n] ")
             except EOFError:

--- a/cli50/__main__.py
+++ b/cli50/__main__.py
@@ -164,8 +164,9 @@ def main():
     if not args["fast"]:
 
         # Determine platform architecture
-        arch = subprocess.check_output(["uname", "-m"], stderr=subprocess.DEVNULL).decode("utf-8").strip()
-        arch = "amd64" if arch == "x86_64" else "arm64"
+        arch = json.loads(subprocess.check_output([
+            "docker", "inspect", f"{IMAGE}:{args['tag']}"
+        ], stderr=subprocess.DEVNULL).decode("utf-8"))[0]["Architecture"]
 
         # Remote digest
         try:

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,6 @@ setup(
         "console_scripts": ["cli50=cli50.__main__:main"]
     },
     url="https://github.com/cs50/cli50",
-    version="7.1.4",
+    version="7.1.5",
     include_package_data=True
 )


### PR DESCRIPTION
This PR addresses [https://github.com/cs50/cli50/issues/105](https://github.com/cs50/cli50/issues/105).

Because cs50/cli:latest is now a multi-arch repo, the repo digest is computed from the manifest body, so it won't match any image digests. To address this issue, we will need to inspect the docker manifest, retrieve the image digest (the image that matched a given platform), and compare it with the remote image digest.